### PR TITLE
Implement expression substitution

### DIFF
--- a/benchmarks/ExpressionTree.cpp
+++ b/benchmarks/ExpressionTree.cpp
@@ -107,7 +107,7 @@ template< typename Container > static void BM_expressionIteration(benchmark::Sta
 		if constexpr (std::is_same_v< typename Container::iterator::value_type, Expression >) {
 			for (const Expression &current : data) {
 				if (current.getType() == lizard::ExpressionType::Literal) {
-					sum += current.getNumerator();
+					sum += current.getLiteral().getNumerator();
 				}
 			}
 		} else {

--- a/include/lizard/core/Expression.hpp
+++ b/include/lizard/core/Expression.hpp
@@ -24,6 +24,8 @@
 #include <utility>
 #include <vector>
 
+#include <hedley.h>
+
 namespace lizard {
 
 template< typename Variable >
@@ -92,6 +94,16 @@ template< typename Variable > auto ConstExpression< Variable >::isRoot() const -
 	return !m_node->hasParent();
 }
 
+template< typename Variable > auto ConstExpression< Variable >::size() const -> Numeric::numeric_type {
+	if (m_nodeID == m_tree->m_rootID) {
+		// The represented expression is the same as the one represented by the associated expression tree
+		// -> Use it to obtain the size as that's more efficient
+		return m_tree->size();
+	}
+
+	return computeSize();
+}
+
 template< typename Variable > auto ConstExpression< Variable >::nodeID() const -> const Numeric & {
 	return m_nodeID;
 }
@@ -102,6 +114,19 @@ template< typename Variable > auto ConstExpression< Variable >::node() const -> 
 
 template< typename Variable > auto ConstExpression< Variable >::tree() const -> const ExpressionTree< Variable > & {
 	return *m_tree;
+}
+
+template< typename Variable > auto ConstExpression< Variable >::computeSize() const -> Numeric::numeric_type {
+	switch (getCardinality()) {
+		case ExpressionCardinality::Nullary:
+			return 1;
+		case ExpressionCardinality::Unary:
+			return getLeftArg().computeSize() + 1;
+		case ExpressionCardinality::Binary:
+			return getLeftArg().computeSize() + getRightArg().computeSize() + 1;
+	}
+
+	HEDLEY_UNREACHABLE();
 }
 
 

--- a/include/lizard/core/Expression.hpp
+++ b/include/lizard/core/Expression.hpp
@@ -15,6 +15,7 @@
 #include "lizard/core/Node.hpp"
 #include "lizard/core/Numeric.hpp"
 #include "lizard/core/SignedCast.hpp"
+#include "lizard/core/details/ExpressionTreeIteratorCore.hpp"
 #include "lizard/core/type_traits.hpp"
 
 #include <cassert>
@@ -39,6 +40,12 @@ template< typename Variable > auto ConstExpression< Variable >::getCardinality()
 
 template< typename Variable > auto ConstExpression< Variable >::getType() const -> ExpressionType {
 	return m_node->getType();
+}
+
+template< typename Variable > auto ConstExpression< Variable >::getParent() const -> ConstExpression< Variable > {
+	assert(!isRoot());
+
+	return { m_node->getParent(), m_tree->m_nodes[m_node->getParent()], *m_tree };
 }
 
 template< typename Variable > auto ConstExpression< Variable >::getVariable() const -> const Variable & {
@@ -166,7 +173,7 @@ Expression< Variable >::Expression(Numeric nodeID, Node &node, ExpressionTree< V
 
 template< typename Variable > auto Expression< Variable >::getVariable() -> Variable & {
 	// NOLINTNEXTLINE(*-const-cast)
-	return const_cast< Variable & >(std::as_const(*this).getVariable());
+	return const_cast< Variable & >(ConstExpression< Variable >::getVariable());
 }
 
 
@@ -201,19 +208,14 @@ template< typename Variable > auto Expression< Variable >::getArg() -> Expressio
 	return { node().getLeftChild(), tree().m_nodes[node().getLeftChild()], tree() };
 }
 
-template< typename Variable > auto Expression< Variable >::nodeID() -> Numeric & {
-	// NOLINTNEXTLINE(*-const-cast)
-	return const_cast< Numeric & >(std::as_const(*this).nodeID());
-}
-
 template< typename Variable > auto Expression< Variable >::node() -> Node & {
 	// NOLINTNEXTLINE(*-const-cast)
-	return const_cast< Node & >(std::as_const(*this).node());
+	return const_cast< Node & >(ConstExpression< Variable >::node());
 }
 
 template< typename Variable > auto Expression< Variable >::tree() -> ExpressionTree< Variable > & {
 	// NOLINTNEXTLINE(*-const-cast)
-	return const_cast< ExpressionTree< Variable > & >(std::as_const(*this).tree());
+	return const_cast< ExpressionTree< Variable > & >(ConstExpression< Variable >::tree());
 }
 
 

--- a/include/lizard/core/Expression.hpp
+++ b/include/lizard/core/Expression.hpp
@@ -27,9 +27,8 @@
 namespace lizard {
 
 template< typename Variable >
-ConstExpression< Variable >::ConstExpression(Numeric nodeIndex, const Node &node,
-											 const ExpressionTree< Variable > &tree)
-	: m_nodeIndex(std::move(nodeIndex)), m_node(&node), m_tree(&tree) {
+ConstExpression< Variable >::ConstExpression(Numeric nodeID, const Node &node, const ExpressionTree< Variable > &tree)
+	: m_nodeID(std::move(nodeID)), m_node(&node), m_tree(&tree) {
 }
 
 template< typename Variable > auto ConstExpression< Variable >::getCardinality() const -> ExpressionCardinality {
@@ -93,8 +92,8 @@ template< typename Variable > auto ConstExpression< Variable >::isRoot() const -
 	return !m_node->hasParent();
 }
 
-template< typename Variable > auto ConstExpression< Variable >::nodeIndex() const -> const Numeric & {
-	return m_nodeIndex;
+template< typename Variable > auto ConstExpression< Variable >::nodeID() const -> const Numeric & {
+	return m_nodeID;
 }
 
 template< typename Variable > auto ConstExpression< Variable >::node() const -> const Node & {
@@ -109,7 +108,7 @@ template< typename Variable > auto ConstExpression< Variable >::tree() const -> 
 
 template< typename Variable >
 auto operator==(const ConstExpression< Variable > &lhs, const ConstExpression< Variable > &rhs) -> bool {
-	return lhs.m_nodeIndex == rhs.m_nodeIndex && *lhs.m_node == *rhs.m_node && lhs.m_tree == rhs.m_tree;
+	return lhs.m_nodeID == rhs.m_nodeID && *lhs.m_node == *rhs.m_node && lhs.m_tree == rhs.m_tree;
 }
 
 template< typename Variable >
@@ -119,7 +118,7 @@ auto operator!=(const ConstExpression< Variable > &lhs, const ConstExpression< V
 
 template< typename Variable >
 auto operator<<(std::ostream &stream, const ConstExpression< Variable > &expr) -> std::ostream & {
-	return stream << "Node " << expr.m_nodeIndex << ": " << *expr.m_node << " (" << expr.m_tree << ")";
+	return stream << "Node " << expr.m_nodeID << ": " << *expr.m_node << " (" << expr.m_tree << ")";
 }
 
 
@@ -136,8 +135,8 @@ auto operator<<(std::ostream &stream, const ConstExpression< Variable > &expr) -
  */
 
 template< typename Variable >
-Expression< Variable >::Expression(Numeric nodeIndex, Node &node, ExpressionTree< Variable > &tree)
-	: ConstExpression< Variable >(std::move(nodeIndex), node, tree) {
+Expression< Variable >::Expression(Numeric nodeID, Node &node, ExpressionTree< Variable > &tree)
+	: ConstExpression< Variable >(std::move(nodeID), node, tree) {
 }
 
 template< typename Variable > auto Expression< Variable >::getVariable() -> Variable & {
@@ -177,9 +176,9 @@ template< typename Variable > auto Expression< Variable >::getArg() -> Expressio
 	return { node().getLeftChild(), tree().m_nodes[node().getLeftChild()], tree() };
 }
 
-template< typename Variable > auto Expression< Variable >::nodeIndex() -> Numeric & {
+template< typename Variable > auto Expression< Variable >::nodeID() -> Numeric & {
 	// NOLINTNEXTLINE(*-const-cast)
-	return const_cast< Numeric & >(std::as_const(*this).nodeIndex());
+	return const_cast< Numeric & >(std::as_const(*this).nodeID());
 }
 
 template< typename Variable > auto Expression< Variable >::node() -> Node & {

--- a/include/lizard/core/Expression.hpp
+++ b/include/lizard/core/Expression.hpp
@@ -218,6 +218,20 @@ template< typename Variable > auto Expression< Variable >::tree() -> ExpressionT
 	return const_cast< ExpressionTree< Variable > & >(ConstExpression< Variable >::tree());
 }
 
+template< typename Variable > void Expression< Variable >::substituteWith(Variable variable) {
+	tree().substitute(this->nodeID(), std::move(variable));
+}
+
+template< typename Variable > void Expression< Variable >::substituteWith(const ConstExpression< Variable > &expr) {
+	using Iterator = typename ExpressionTree< Variable >::const_post_order_iterator;
+	using Core     = details::ExpressionTreeIteratorCore< Variable, true, TreeTraversal::DepthFirst_PostOrder >;
+
+	Iterator begin(Core::fromRoot(expr.tree(), expr.nodeID()));
+	Iterator end(Core::afterRoot(expr.tree(), expr.nodeID()));
+
+	tree().substitute(this->nodeID(), begin, end);
+}
+
 
 
 // Consistency checks

--- a/include/lizard/core/ExpressionTree.hpp
+++ b/include/lizard/core/ExpressionTree.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "lizard/core/Expression.hpp"
 #include "lizard/core/ExpressionCardinality.hpp"
 #include "lizard/core/ExpressionException.hpp"
 #include "lizard/core/ExpressionOperator.hpp"
@@ -17,6 +18,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <iterator>
 #include <stack>
 #include <type_traits>
 #include <vector>
@@ -181,32 +183,32 @@ public:
 
 	template< TreeTraversal iteration_order = TreeTraversal::DepthFirst_PostOrder >
 	auto begin() -> iterator_template< false, iteration_order > {
-		return { details::ExpressionTreeIteratorCore< Variable, false, iteration_order >(*this, m_root) };
+		return { details::ExpressionTreeIteratorCore< Variable, false, iteration_order >::fromRoot(*this, m_root) };
 	}
 
 	template< TreeTraversal iteration_order = TreeTraversal::DepthFirst_PostOrder >
 	auto end() -> iterator_template< false, iteration_order > {
-		return { details::ExpressionTreeIteratorCore< Variable, false, iteration_order >::createEnd(*this) };
+		return { details::ExpressionTreeIteratorCore< Variable, false, iteration_order >::end(*this) };
 	}
 
 	template< TreeTraversal iteration_order = TreeTraversal::DepthFirst_PostOrder >
 	auto begin() const -> iterator_template< true, iteration_order > {
-		return { details::ExpressionTreeIteratorCore< Variable, true, iteration_order >(*this, m_root) };
+		return { details::ExpressionTreeIteratorCore< Variable, true, iteration_order >::fromRoot(*this, m_root) };
 	}
 
 	template< TreeTraversal iteration_order = TreeTraversal::DepthFirst_PostOrder >
 	auto end() const -> iterator_template< true, iteration_order > {
-		return { details::ExpressionTreeIteratorCore< Variable, true, iteration_order >::createEnd(*this) };
+		return { details::ExpressionTreeIteratorCore< Variable, true, iteration_order >::end(*this) };
 	}
 
 	template< TreeTraversal iteration_order = TreeTraversal::DepthFirst_PostOrder >
 	auto cbegin() const -> iterator_template< true, iteration_order > {
-		return { details::ExpressionTreeIteratorCore< Variable, true, iteration_order >(*this, m_root) };
+		return { details::ExpressionTreeIteratorCore< Variable, true, iteration_order >::fromRoot(*this, m_root) };
 	}
 
 	template< TreeTraversal iteration_order = TreeTraversal::DepthFirst_PostOrder >
 	auto cend() const -> iterator_template< true, iteration_order > {
-		return { details::ExpressionTreeIteratorCore< Variable, true, iteration_order >::createEnd(*this) };
+		return { details::ExpressionTreeIteratorCore< Variable, true, iteration_order >::end(*this) };
 	}
 
 	friend auto operator==(const ExpressionTree &lhs, const ExpressionTree &rhs) -> bool {
@@ -244,6 +246,9 @@ private:
 	std::stack< Numeric > m_consumableNodes;
 	Numeric m_root;
 	std::size_t m_size = 0;
+
+	friend class ConstExpression< Variable >;
+	friend class Expression< Variable >;
 };
 
 

--- a/include/lizard/core/ExpressionTree.hpp
+++ b/include/lizard/core/ExpressionTree.hpp
@@ -76,7 +76,7 @@ public:
 	/**
 	 * @returns Whether this tree is in a valid state
 	 */
-	[[nodiscard]] auto isValid() const -> bool { return isEmpty() || m_root.isValid(); }
+	[[nodiscard]] auto isValid() const -> bool { return isEmpty() || m_rootID.isValid(); }
 
 	/**
 	 * Ensures that the internally used buffers are big enough to hold at least the given amount of nodes and variables
@@ -94,19 +94,19 @@ public:
 		m_variables.clear();
 		m_nodes.clear();
 		m_consumableNodes = {};
-		m_root.reset();
+		m_rootID.reset();
 		m_size = 0;
 	}
 
 	/**
 	 * @returns The root expression in this tree
 	 */
-	auto getRoot() const -> ConstExpression< Variable > { return { m_root, m_nodes[m_root], *this }; }
+	auto getRoot() const -> ConstExpression< Variable > { return { m_rootID, m_nodes[m_rootID], *this }; }
 
 	/**
 	 * @returns The root expression in this tree
 	 */
-	auto getRoot() -> Expression< Variable > { return { m_root, m_nodes[m_root], *this }; }
+	auto getRoot() -> Expression< Variable > { return { m_rootID, m_nodes[m_rootID], *this }; }
 
 	/**
 	 * Adds the given Variable object as a nullary expression to this tree. The general rules for adding nodes
@@ -170,10 +170,10 @@ public:
 
 		if (m_consumableNodes.empty()) {
 			// The node that has consumed the last arguments available thus far must be the new root node
-			m_root = nodeID;
+			m_rootID = nodeID;
 		} else {
 			// At the moment there is no root node as the expression is unfinished
-			m_root = {};
+			m_rootID = {};
 		}
 
 		// Every expression is understood to create (return) a value and therefore, it can be used
@@ -183,7 +183,7 @@ public:
 
 	template< TreeTraversal iteration_order = TreeTraversal::DepthFirst_PostOrder >
 	auto begin() -> iterator_template< false, iteration_order > {
-		return { details::ExpressionTreeIteratorCore< Variable, false, iteration_order >::fromRoot(*this, m_root) };
+		return { details::ExpressionTreeIteratorCore< Variable, false, iteration_order >::fromRoot(*this, m_rootID) };
 	}
 
 	template< TreeTraversal iteration_order = TreeTraversal::DepthFirst_PostOrder >
@@ -193,7 +193,7 @@ public:
 
 	template< TreeTraversal iteration_order = TreeTraversal::DepthFirst_PostOrder >
 	auto begin() const -> iterator_template< true, iteration_order > {
-		return { details::ExpressionTreeIteratorCore< Variable, true, iteration_order >::fromRoot(*this, m_root) };
+		return { details::ExpressionTreeIteratorCore< Variable, true, iteration_order >::fromRoot(*this, m_rootID) };
 	}
 
 	template< TreeTraversal iteration_order = TreeTraversal::DepthFirst_PostOrder >
@@ -203,7 +203,7 @@ public:
 
 	template< TreeTraversal iteration_order = TreeTraversal::DepthFirst_PostOrder >
 	auto cbegin() const -> iterator_template< true, iteration_order > {
-		return { details::ExpressionTreeIteratorCore< Variable, true, iteration_order >::fromRoot(*this, m_root) };
+		return { details::ExpressionTreeIteratorCore< Variable, true, iteration_order >::fromRoot(*this, m_rootID) };
 	}
 
 	template< TreeTraversal iteration_order = TreeTraversal::DepthFirst_PostOrder >
@@ -244,7 +244,7 @@ private:
 	std::vector< Variable > m_variables;
 	std::vector< Node > m_nodes;
 	std::stack< Numeric > m_consumableNodes;
-	Numeric m_root;
+	Numeric m_rootID;
 	Numeric::numeric_type m_size = 0;
 
 	friend class ConstExpression< Variable >;

--- a/include/lizard/core/ExpressionTree.hpp
+++ b/include/lizard/core/ExpressionTree.hpp
@@ -167,6 +167,7 @@ public:
 
 		// Store the expression as a new node
 		m_nodes.push_back(std::move(node));
+		m_size++;
 
 		if (m_consumableNodes.empty()) {
 			// The node that has consumed the last arguments available thus far must be the new root node

--- a/include/lizard/core/ExpressionTree.hpp
+++ b/include/lizard/core/ExpressionTree.hpp
@@ -257,6 +257,10 @@ private:
 		return Node{ ExpressionType::Variable, Numeric(static_cast< Numeric::numeric_type >(m_variables.size() - 1)) };
 	}
 
+	/**
+	 * Substitutes the Node with the given ID with a new Node representing the provided Variable
+	 * (which will be stored inside this tree).
+	 */
 	void substitute(const Numeric &nodeID, Variable variable) {
 		assert(nodeID < m_nodes.size());
 
@@ -267,6 +271,11 @@ private:
 		m_nodes[nodeID] = std::move(node);
 	}
 
+	/**
+	 * Substitutes the Node with the given ID with the sub-tree iterated over by means of the provided
+	 * iterator pair. The iteration order is expected to be depth-first, post-order. Using any other
+	 * iteration / tree traversal order is not supported!
+	 */
 	template< typename Iterator > void substitute(const Numeric &nodeID, Iterator iter, const Iterator end) {
 		static_assert(
 			std::is_base_of_v< ConstExpression< Variable >, typename std::iterator_traits< Iterator >::value_type >,

--- a/include/lizard/core/ExpressionTree.hpp
+++ b/include/lizard/core/ExpressionTree.hpp
@@ -71,7 +71,7 @@ public:
 	/**
 	 * @returns The amount of nodes currently in this tree
 	 */
-	[[nodiscard]] auto size() const -> std::size_t { return m_size; }
+	[[nodiscard]] auto size() const -> Numeric::numeric_type { return m_size; }
 
 	/**
 	 * @returns Whether this tree is in a valid state
@@ -245,7 +245,7 @@ private:
 	std::vector< Node > m_nodes;
 	std::stack< Numeric > m_consumableNodes;
 	Numeric m_root;
-	std::size_t m_size = 0;
+	Numeric::numeric_type m_size = 0;
 
 	friend class ConstExpression< Variable >;
 	friend class Expression< Variable >;

--- a/include/lizard/core/Expression_fwd.hpp
+++ b/include/lizard/core/Expression_fwd.hpp
@@ -8,6 +8,7 @@
 #include "lizard/core/ExpressionCardinality.hpp"
 #include "lizard/core/ExpressionOperator.hpp"
 #include "lizard/core/ExpressionType.hpp"
+#include "lizard/core/Fraction.hpp"
 #include "lizard/core/Numeric.hpp"
 #include "lizard/core/type_traits.hpp"
 
@@ -65,25 +66,11 @@ public:
 	[[nodiscard]] auto getOperator() const -> ExpressionOperator;
 
 	/**
-	 * @returns The numerator of the represented literal
+	 * @returns The literal value this expression represents
 	 *
 	 * Note: If this expression doesn't actually represent a literal value, calling this function is undefined behavior!
 	 */
-	[[nodiscard]] auto getNumerator() const -> std::int32_t;
-
-	/**
-	 * @returns The denominator of the represented literal
-	 *
-	 * Note: If this expression doesn't actually represent a literal value, calling this function is undefined behavior!
-	 */
-	[[nodiscard]] auto getDenominator() const -> std::int32_t;
-
-	/**
-	 * @returns The numerical value of the represented literal (as a floating point value)
-	 *
-	 * Note: If this expression doesn't actually represent a literal value, calling this function is undefined behavior!
-	 */
-	[[nodiscard]] auto getLiteral() const -> double;
+	[[nodiscard]] auto getLiteral() const -> Fraction;
 
 	/**
 	 * @returns The Expression representing the left argument of the represented binary expression
@@ -160,7 +147,7 @@ public:
 	 *
 	 * Note: If this expression doesn't actually represent a literal value, calling this function is undefined behavior!
 	 */
-	void setLiteral(std::int32_t numerator, std::int32_t denominator = 1);
+	void setLiteral(const Fraction &fraction);
 
 	/**
 	 * @returns The Expression representing the left argument of the represented binary expression

--- a/include/lizard/core/Expression_fwd.hpp
+++ b/include/lizard/core/Expression_fwd.hpp
@@ -10,6 +10,7 @@
 #include "lizard/core/ExpressionType.hpp"
 #include "lizard/core/Fraction.hpp"
 #include "lizard/core/Numeric.hpp"
+#include "lizard/core/TreeTraversal.hpp"
 #include "lizard/core/type_traits.hpp"
 
 #include <cstdint>
@@ -21,6 +22,10 @@ namespace lizard {
 
 template< typename > class ExpressionTree;
 class Node;
+
+namespace details {
+	template< typename, bool, TreeTraversal > class ExpressionTreeIteratorCore;
+}
 
 /**
  * Class providing a rich API for accessing individual (sub-)expressions in an expression tree.
@@ -50,6 +55,13 @@ public:
 	 * @returns The type of this expression
 	 */
 	[[nodiscard]] auto getType() const -> ExpressionType;
+
+	/**
+	 * @returns The parent of the currently represented expression
+	 *
+	 * Note: Calling this function on a root expression (isRoot() returns true) is undefined behavior!
+	 */
+	[[nodiscard]] auto getParent() const -> ConstExpression;
 
 	/**
 	 * @returns The represented variable object
@@ -120,6 +132,9 @@ private:
 	const Node *m_node;
 	const ExpressionTree< Variable > *m_tree;
 
+	template< typename > friend class ExpressionTree;
+	template< typename, bool, TreeTraversal > friend class details::ExpressionTreeIteratorCore;
+
 	/**
 	 * @returns The computed size of this expression
 	 */
@@ -181,11 +196,11 @@ public:
 	[[nodiscard]] auto getArg() -> Expression;
 
 protected:
-	[[nodiscard]] auto nodeID() -> Numeric &;
-
 	[[nodiscard]] auto node() -> Node &;
 
 	[[nodiscard]] auto tree() -> ExpressionTree< Variable > &;
+
+	template< typename, bool, TreeTraversal > friend class details::ExpressionTreeIteratorCore;
 };
 
 } // namespace lizard

--- a/include/lizard/core/Expression_fwd.hpp
+++ b/include/lizard/core/Expression_fwd.hpp
@@ -34,7 +34,7 @@ class Node;
  */
 template< typename Variable > class ConstExpression {
 public:
-	ConstExpression(Numeric nodeIndex, const Node &node, const ExpressionTree< Variable > &tree);
+	ConstExpression(Numeric nodeID, const Node &node, const ExpressionTree< Variable > &tree);
 	ConstExpression(const ConstExpression &)     = default;
 	ConstExpression(ConstExpression &&) noexcept = default;
 	~ConstExpression()                           = default;
@@ -106,12 +106,12 @@ public:
 	friend auto operator<<(std::ostream &stream, const ConstExpression< V > &expr) -> std::ostream &;
 
 protected:
-	[[nodiscard]] auto nodeIndex() const -> const Numeric &;
+	[[nodiscard]] auto nodeID() const -> const Numeric &;
 	[[nodiscard]] auto node() const -> const Node &;
 	[[nodiscard]] auto tree() const -> const ExpressionTree< Variable > &;
 
 private:
-	Numeric m_nodeIndex;
+	Numeric m_nodeID;
 	const Node *m_node;
 	const ExpressionTree< Variable > *m_tree;
 };
@@ -130,7 +130,7 @@ private:
  */
 template< typename Variable > class Expression : public ConstExpression< Variable > {
 public:
-	Expression(Numeric nodeIndex, Node &node, ExpressionTree< Variable > &tree);
+	Expression(Numeric nodeID, Node &node, ExpressionTree< Variable > &tree);
 
 	// Inherit constructors from base class
 	using ConstExpression< Variable >::ConstExpression;
@@ -171,7 +171,7 @@ public:
 	[[nodiscard]] auto getArg() -> Expression;
 
 protected:
-	[[nodiscard]] auto nodeIndex() -> Numeric &;
+	[[nodiscard]] auto nodeID() -> Numeric &;
 
 	[[nodiscard]] auto node() -> Node &;
 

--- a/include/lizard/core/Expression_fwd.hpp
+++ b/include/lizard/core/Expression_fwd.hpp
@@ -134,6 +134,7 @@ private:
 
 	template< typename > friend class ExpressionTree;
 	template< typename, bool, TreeTraversal > friend class details::ExpressionTreeIteratorCore;
+	template< typename > friend class Expression;
 
 	/**
 	 * @returns The computed size of this expression
@@ -194,6 +195,10 @@ public:
 	 * Note: If this expression is not actually unary, calling this function is undefined behavior!
 	 */
 	[[nodiscard]] auto getArg() -> Expression;
+
+	void substituteWith(Variable variable);
+
+	void substituteWith(const ConstExpression< Variable > &expr);
 
 protected:
 	[[nodiscard]] auto node() -> Node &;

--- a/include/lizard/core/Expression_fwd.hpp
+++ b/include/lizard/core/Expression_fwd.hpp
@@ -196,8 +196,14 @@ public:
 	 */
 	[[nodiscard]] auto getArg() -> Expression;
 
+	/**
+	 * Replaces the represented expression with an expression containing only the given Variable.
+	 */
 	void substituteWith(Variable variable);
 
+	/**
+	 * Replaces the represented expression with the provided one.
+	 */
 	void substituteWith(const ConstExpression< Variable > &expr);
 
 protected:

--- a/include/lizard/core/Expression_fwd.hpp
+++ b/include/lizard/core/Expression_fwd.hpp
@@ -98,6 +98,11 @@ public:
 	 */
 	[[nodiscard]] auto isRoot() const -> bool;
 
+	/**
+	 * @returns The size of the expression rooted at the currently represented element
+	 */
+	[[nodiscard]] auto size() const -> Numeric::numeric_type;
+
 	template< typename V >
 	friend auto operator==(const ConstExpression< V > &lhs, const ConstExpression< V > &rhs) -> bool;
 	template< typename V >
@@ -114,6 +119,11 @@ private:
 	Numeric m_nodeID;
 	const Node *m_node;
 	const ExpressionTree< Variable > *m_tree;
+
+	/**
+	 * @returns The computed size of this expression
+	 */
+	[[nodiscard]] auto computeSize() const -> Numeric::numeric_type;
 };
 
 

--- a/include/lizard/core/Fraction.hpp
+++ b/include/lizard/core/Fraction.hpp
@@ -8,8 +8,13 @@
 #include <cstdint>
 #include <iosfwd>
 #include <limits>
+#include <sstream>
+#include <string>
 
 namespace lizard {
+
+class Fraction;
+auto operator<<(std::ostream &stream, const Fraction &fraction) -> std::ostream &;
 
 /**
  * Simple representation of a fraction using numerator and denominator
@@ -109,6 +114,12 @@ public:
 		return fraction;
 	}
 
+	explicit operator std::string() const {
+		std::stringstream sstream;
+		sstream << *this;
+		return sstream.str();
+	}
+
 
 private:
 	field_type m_numerator   = 0;
@@ -138,7 +149,5 @@ constexpr auto operator>(const Fraction &lhs, const Fraction &rhs) -> bool {
 constexpr auto operator>=(const Fraction &lhs, const Fraction &rhs) -> bool {
 	return lhs == rhs || lhs > rhs;
 }
-
-auto operator<<(std::ostream &stream, const Fraction &fraction) -> std::ostream &;
 
 } // namespace lizard

--- a/include/lizard/core/details/ExpressionTreeIteratorCore.hpp
+++ b/include/lizard/core/details/ExpressionTreeIteratorCore.hpp
@@ -21,8 +21,10 @@
 namespace lizard {
 
 template< typename > class ExpressionTree;
+template< typename > class Expression;
+template< typename > class ConstExpression;
 
-}
+} // namespace lizard
 
 namespace lizard::details {
 

--- a/include/lizard/core/details/ExpressionTreeIteratorCore.hpp
+++ b/include/lizard/core/details/ExpressionTreeIteratorCore.hpp
@@ -11,6 +11,7 @@
 #include "lizard/core/Numeric.hpp"
 #include "lizard/core/TreeTraversal.hpp"
 
+#include <iostream>
 #include <iterator>
 
 #include <iterators/is_semantically_const.hpp>
@@ -46,22 +47,122 @@ public:
 		std::conditional_t< isConst, const ExpressionTree< Variable > &, ExpressionTree< Variable > & >;
 	using tree_pointer    = std::add_pointer_t< std::remove_reference_t< tree_reference > >;
 	using expression_type = std::conditional_t< isConst, ConstExpression< Variable >, Expression< Variable > >;
+	using node_type       = std::conditional_t< isConst, const Node, Node >;
 
 	/**
-	 * Creates an end() iterator - aka: an iterator that indicates the end of iteration
+	 * @param tree The ExpressionTree the created core shall be associated with
 	 *
-	 * @param tree The expression tree this iterator is supposed to be associated with
+	 * @returns An iterator core in a state that is only ever reached, if a all Nodes in the tree have been visited
+	 * (regardless of iteration order)
 	 */
-	static auto createEnd(tree_reference tree) { return ExpressionTreeIteratorCore(tree, Numeric{}); }
+	static auto end(tree_reference tree) -> ExpressionTreeIteratorCore { return { &tree, Numeric{}, Numeric{} }; }
 
 	/**
-	 * @param tree The expression tree this iterator is supposed to be iterating / supposed to be associated with
-	 * @param rootID The ID of the root node from where to start the iteration
+	 * @param tree The ExpressionTree the created core shall be associated with
+	 * @param nodeID The ID of the referenced Node
+	 *
+	 * @returns An iterator core in a state that will dereference to the given node
 	 */
-	ExpressionTreeIteratorCore(tree_reference tree, Numeric rootID) : m_tree(&tree), m_currentID(std::move(rootID)) {
-		if (m_currentID.isValid()) {
-			skipToFirst();
+	static auto at(tree_reference tree, Numeric nodeID) -> ExpressionTreeIteratorCore {
+		return { &tree, nodeID, nodeID };
+	}
+
+	static auto at(tree_reference tree, const expression_type &expr) -> ExpressionTreeIteratorCore {
+		return at(tree, expr.nodeID());
+	}
+
+	/**
+	 * @param tree The ExpressionTree the created core shall be associated with
+	 * @param nodeID The ID of the referenced Node
+	 *
+	 * @returns An iterator core in a state that will dereference to the Node that will be visited after the provided
+	 * Node (if any)
+	 */
+	static auto after(tree_reference tree, Numeric nodeID) -> ExpressionTreeIteratorCore {
+		ExpressionTreeIteratorCore core = at(tree, nodeID);
+		core.increment();
+
+		return core;
+	}
+
+	static auto after(tree_reference tree, const expression_type &expr) -> ExpressionTreeIteratorCore {
+		return after(tree, expr.nodeID());
+	}
+
+	/**
+	 * @param tree The ExpressionTree the created core shall be associated with
+	 * @param nodeID The ID of Node that shall be considered as root Node
+	 *
+	 * @returns An iterator core in a state that will dereference to the Node has to be visited in order traverse the
+	 * tree represented by the given root Node (with its sub-tree) in the respective iteration order
+	 */
+	static auto fromRoot(tree_reference tree, Numeric nodeID) -> ExpressionTreeIteratorCore {
+		switch (iterationOrder) {
+			case TreeTraversal::DepthFirst_PreOrder:
+				// The root node is in fact the first Node to be visited
+				return at(tree, nodeID);
+			case TreeTraversal::DepthFirst_PostOrder:
+			case TreeTraversal::DepthFirst_InOrder:
+				// Start with a step that indicates that we are currently mid-traversal (coming from the Node's parent).
+				// Thus, calling increment() on such a state will go and find the Node that shall be visited next.
+				assert(nodeID < tree.m_nodes.size());
+				const Node &node = tree.m_nodes[nodeID];
+				ExpressionTreeIteratorCore core(&tree, nodeID, node.getParent());
+				core.increment();
+				return core;
 		}
+
+		HEDLEY_UNREACHABLE();
+	}
+
+	static auto fromRoot(tree_reference tree, const expression_type &expr) -> ExpressionTreeIteratorCore {
+		return fromRoot(tree, expr.nodeID());
+	}
+
+	/**
+	 * @param tree The ExpressionTree the created core shall be associated with
+	 * @param nodeID The ID of Node that shall be considered as root Node
+	 *
+	 * @returns An iterator core in a state that will dereference to whatever Node (if any) is visited after the
+	 * sub-tree under (and including) the given root Node has been visited.
+	 */
+	static auto afterRoot(tree_reference tree, Numeric nodeID) -> ExpressionTreeIteratorCore {
+		assert(nodeID < tree.m_nodes.size());
+
+		ExpressionTreeIteratorCore core = [&]() -> ExpressionTreeIteratorCore {
+			// Create a state that will lead to the first Node that is outside the given sub-tree upon increment
+			const Node &node = tree.m_nodes[nodeID];
+			switch (iterationOrder) {
+				case TreeTraversal::DepthFirst_InOrder:
+					// State: Either just finished visiting the Node's right sub-tree or - if there is no right
+					// sub-tree - just visited the current Node
+					return node.hasRightChild() ? at(tree, node.getRightChild()) : at(tree, nodeID);
+				case TreeTraversal::DepthFirst_PostOrder:
+					// State: just visited Root node
+					return at(tree, nodeID);
+				case TreeTraversal::DepthFirst_PreOrder:
+					if (node.hasRightChild()) {
+						// State: Just visited Node's right sub-tree
+						return at(tree, node.getRightChild());
+					} else if (node.hasLeftChild()) {
+						// State: Just visited Node's left sub-tree
+						return at(tree, node.getLeftChild());
+					} else {
+						// State: Just visited the Node itself
+						return at(tree, nodeID);
+					}
+
+					HEDLEY_UNREACHABLE();
+			}
+		}();
+
+		core.increment();
+
+		return core;
+	}
+
+	static auto afterRoot(tree_reference tree, const ConstExpression< Variable > &expr) -> ExpressionTreeIteratorCore {
+		return afterRoot(tree, expr.nodeID());
 	}
 
 	ExpressionTreeIteratorCore(const ExpressionTreeIteratorCore &)     = default;
@@ -80,9 +181,7 @@ public:
 	/**
 	 * This function will be called if the iterator constructed from this core will be dereferenced
 	 */
-	[[nodiscard]] auto dereference() const -> expression_type {
-		return { m_currentID, m_tree->m_nodes[m_currentID], *m_tree };
-	}
+	[[nodiscard]] auto dereference() const -> expression_type { return { m_currentID, toNode(m_currentID), *m_tree }; }
 
 	/**
 	 * This function will be called if the iterator constructed from this core is incremented
@@ -97,26 +196,45 @@ public:
 		return other.m_tree == m_tree && other.m_currentID == m_currentID && other.m_previousID == m_previousID;
 	}
 
+
+	friend auto operator<<(std::ostream &stream, const ExpressionTreeIteratorCore &core) -> std::ostream & {
+		stream << "IteratorCore{";
+		if (!core.m_currentID.isValid()) {
+			// This is the end tag
+			assert(!core.m_previousID.isValid());
+			return stream << "}";
+		}
+		if (core.m_previousID == core.m_currentID) {
+			stream << " >";
+		}
+		stream << " " << core.toNode(core.m_currentID);
+		if (core.m_previousID == core.m_currentID) {
+			stream << " <";
+		} else if (core.m_previousID.isValid()) {
+			stream << " <- " << core.toNode(core.m_previousID);
+		}
+		return stream << " }";
+	}
+
 private:
 	tree_pointer m_tree;
 	Numeric m_currentID;
 	Numeric m_previousID;
 
 	/**
-	 * Ensures that this iterator will dereference to the correct element (depending on the chosen iteration order)
+	 * Ctor for internal use
 	 */
-	void skipToFirst() {
-		switch (iterationOrder) {
-			case TreeTraversal::DepthFirst_PreOrder:
-				// In these cases, we actually start visiting the root node before doing anything else
-				m_previousID = m_currentID;
-				break;
-			case TreeTraversal::DepthFirst_PostOrder:
-			case TreeTraversal::DepthFirst_InOrder:
-				// In these cases, the root node is not the first node visited
-				skipToNext();
-				break;
-		}
+	ExpressionTreeIteratorCore(tree_pointer tree, Numeric currentID, Numeric previousID)
+		: m_tree(tree), m_currentID(currentID), m_previousID(previousID) {}
+
+	[[nodiscard]] auto toNode(const Numeric &nodeID) -> node_type & {
+		assert(nodeID < m_tree->m_nodes.size());
+		return m_tree->m_nodes[nodeID];
+	}
+
+	[[nodiscard]] auto toNode(const Numeric &nodeID) const -> const node_type & {
+		// NOLINTNEXTLINE(*-const-cast)
+		return const_cast< ExpressionTreeIteratorCore * >(this)->toNode(nodeID);
 	}
 
 	/**
@@ -142,7 +260,7 @@ private:
 		bool done = false;
 
 		do {
-			const Node &currentNode = m_tree->m_nodes[m_currentID];
+			const Node &currentNode = toNode(m_currentID);
 
 			depth_first::TraversalStep step = depth_first::stepTraversal(currentNode, m_currentID, m_previousID,
 																		 orderToDepthFirstOrder(iterationOrder));
@@ -166,8 +284,19 @@ private:
 	template< typename, bool, TreeTraversal > friend class ExpressionTreeIteratorCore;
 };
 
+template< typename Variable, bool isConst, TreeTraversal traversal >
+auto operator==(const ExpressionTreeIteratorCore< Variable, isConst, traversal > &lhs,
+				const ExpressionTreeIteratorCore< Variable, isConst, traversal > &rhs) {
+	return lhs.equals(rhs);
+}
+template< typename Variable, bool isConst, TreeTraversal traversal >
+auto operator!=(const ExpressionTreeIteratorCore< Variable, isConst, traversal > &lhs,
+				const ExpressionTreeIteratorCore< Variable, isConst, traversal > &rhs) {
+	return !lhs.equals(rhs);
+}
 
-// A few consistency checks that ensure above implementation is reasobale
+
+// A few consistency checks that ensure above implementation is reasonable
 static_assert(
 	std::is_convertible_v< ExpressionTreeIteratorCore< int, false >, ExpressionTreeIteratorCore< int, true > >,
 	"Iterator cores must be convertible from mutable to const");

--- a/src/core/Fraction.cpp
+++ b/src/core/Fraction.cpp
@@ -10,7 +10,15 @@
 namespace lizard {
 
 auto operator<<(std::ostream &stream, const Fraction &fraction) -> std::ostream & {
-	return stream << fraction.getNumerator() << " / " << fraction.getDenominator();
+	const Fraction::field_type numerator   = fraction.getNumerator();
+	const Fraction::field_type denominator = fraction.getDenominator();
+
+	stream << numerator;
+	if (numerator > 0 && denominator != 1) {
+		stream << " / " << denominator;
+	}
+
+	return stream;
 }
 
 } // namespace lizard

--- a/src/core/Node.cpp
+++ b/src/core/Node.cpp
@@ -72,8 +72,7 @@ void Node::setParent(Numeric parentID) {
 }
 
 auto Node::hasLeftChild() const -> bool {
-	assert(getCardinality() != ExpressionCardinality::Nullary); // NOLINT
-	return m_left.isValid();
+	return getCardinality() != ExpressionCardinality::Nullary && m_left.isValid();
 }
 
 auto Node::getLeftChild() const -> Numeric {
@@ -86,8 +85,7 @@ void Node::setLeftChild(Numeric childID) {
 }
 
 auto Node::hasRightChild() const -> bool {
-	assert(getCardinality() == ExpressionCardinality::Binary); // NOLINT
-	return m_right.isValid();
+	return getCardinality() == ExpressionCardinality::Binary && m_right.isValid();
 }
 
 auto Node::getRightChild() const -> Numeric {

--- a/tests/core/ExpressionTreeTest.cpp
+++ b/tests/core/ExpressionTreeTest.cpp
@@ -115,7 +115,7 @@ auto evaluate(const ExpressionTree< Variable > &tree, const std::unordered_map< 
 					resultStack.push(variables.at(expression.getVariable().name));
 				} else {
 					// We expect to work with integers only
-					resultStack.push(expression.getNumerator());
+					resultStack.push(expression.getLiteral().getNumerator());
 				}
 				break;
 		}
@@ -198,7 +198,7 @@ protected:
 					break;
 				case ExpressionType::Literal:
 					// We expect to only find integer literals in our tests
-					visitedNodeContents.push_back(std::to_string(static_cast< int >(current.getLiteral())));
+					visitedNodeContents.push_back(static_cast< std::string >(current.getLiteral()));
 					break;
 				case ExpressionType::Operator:
 					switch (current.getOperator()) {

--- a/tests/core/ExpressionTreeTest.cpp
+++ b/tests/core/ExpressionTreeTest.cpp
@@ -548,3 +548,20 @@ INSTANTIATE_TEST_SUITE_P(ExpressionTree, EvaluationTest,
 							 std::tuple< std::string, int >{ "2 a + 4 2 -1 b * + * *", 40 },
 							 // 2 + (4 * (a * (2 + -3) + b) + -1 * b) + (4 * 3 * 2 * 1)
 							 std::tuple< std::string, int >{ "2 4 a 2 -3 + * b + * -1 b * + + 4 3 * 2 * 1 * +", 74 }));
+
+
+TEST(ExpressionTree, size) {
+	/**
+	 *   *
+	 *  / \
+	 * 1   +
+	 *    / \
+	 *   2   3
+	 */
+	ExpressionTree< Variable > tree = treeFromPostfix("1 2 3 + *");
+
+	EXPECT_EQ(tree.size(), 5);
+	EXPECT_EQ(tree.getRoot().size(), 5);
+	EXPECT_EQ(tree.getRoot().getLeftArg().size(), 1);
+	EXPECT_EQ(tree.getRoot().getRightArg().size(), 3);
+}

--- a/tests/core/ExpressionTreeTest.cpp
+++ b/tests/core/ExpressionTreeTest.cpp
@@ -451,10 +451,6 @@ template< TreeTraversal traversalOrder, bool isConst > void test_partial_iterati
 		auto begin = Iterator(Core::fromRoot(tree, tree.getRoot().getLeftArg()));
 		auto end   = Iterator(Core::afterRoot(tree, tree.getRoot().getLeftArg()));
 
-		std::cout << "Root: " << tree.getRoot() << std::endl;
-		std::cout << "Left arg: " << tree.getRoot().getLeftArg() << std::endl;
-		std::cout << "First visited: " << *begin << std::endl;
-
 		visitedNodes       = visitNodes(begin, end);
 		expectedNodeVisits = [&]() -> std::vector< std::string > {
 			switch (traversalOrder) {

--- a/tests/core/ExpressionTreeTest.cpp
+++ b/tests/core/ExpressionTreeTest.cpp
@@ -147,17 +147,6 @@ TEST(ExpressionTree, construction) {
 	ASSERT_EQ(tree, other);
 }
 
-template< TreeTraversal iteration_order, typename TreeType >
-void testTreeIteration(const TreeType &tree,
-					   const std::vector< Expression< expression_tree_variable_t< TreeType > > > &expectedSequence) {
-	std::vector< ConstExpression< expression_tree_variable_t< TreeType > > > producedSequence;
-
-	for (auto it = tree.template begin< iteration_order >(); it != tree.template end< iteration_order >(); ++it) {
-		producedSequence.push_back(*it);
-	}
-
-	ASSERT_EQ(producedSequence, expectedSequence);
-}
 
 class IterationTest
 	: public ::testing::TestWithParam< std::tuple< std::string, TreeTraversal, std::vector< std::string > > > {

--- a/tests/core/ExpressionTreeTest.cpp
+++ b/tests/core/ExpressionTreeTest.cpp
@@ -9,6 +9,7 @@
 #include "lizard/core/ExpressionOperator.hpp"
 #include "lizard/core/Node.hpp"
 #include "lizard/core/TreeTraversal.hpp"
+#include "lizard/core/details/ExpressionTreeIteratorCore.hpp"
 #include "lizard/core/type_traits.hpp"
 
 #include <gmock/gmock.h>
@@ -16,12 +17,15 @@
 
 #include <array>
 #include <cassert>
+#include <map>
 #include <sstream>
 #include <stack>
 #include <string>
 #include <tuple>
 #include <unordered_map>
 #include <vector>
+
+#include <hedley.h>
 
 struct Variable {
 	std::string name;
@@ -148,97 +152,376 @@ TEST(ExpressionTree, construction) {
 }
 
 
-class IterationTest
-	: public ::testing::TestWithParam< std::tuple< std::string, TreeTraversal, std::vector< std::string > > > {
-public:
-	using ParamPack = std::tuple< std::string, TreeTraversal, std::vector< std::string > >;
+template< typename Iterator > auto visitNodes(Iterator begin, Iterator end) -> std::vector< std::string > {
+	std::vector< ConstExpression< Variable > > visitedExpressions;
 
-protected:
-	template< typename TreeType >
-	auto visitNodes(TreeTraversal traversalOrder, TreeType &tree) -> std::vector< std::string > {
-		std::vector< ConstExpression< Variable > > visitedExpressions;
-
-		switch (traversalOrder) {
-			case TreeTraversal::DepthFirst_InOrder: {
-				for (auto iter = tree.template begin< TreeTraversal::DepthFirst_InOrder >();
-					 iter != tree.template end< TreeTraversal::DepthFirst_InOrder >(); ++iter) {
-					visitedExpressions.push_back(*iter);
-				}
-			} break;
-			case TreeTraversal::DepthFirst_PreOrder: {
-				for (auto iter = tree.template begin< TreeTraversal::DepthFirst_PreOrder >();
-					 iter != tree.template end< TreeTraversal::DepthFirst_PreOrder >(); ++iter) {
-					visitedExpressions.push_back(*iter);
-				}
-			} break;
-			case TreeTraversal::DepthFirst_PostOrder: {
-				for (auto iter = tree.template begin< TreeTraversal::DepthFirst_PostOrder >();
-					 iter != tree.template end< TreeTraversal::DepthFirst_PostOrder >(); ++iter) {
-					visitedExpressions.push_back(*iter);
-				}
-			} break;
-		}
-
-		std::vector< std::string > visitedNodeContents;
-		for (ConstExpression< Variable > &current : visitedExpressions) {
-			switch (current.getType()) {
-				case ExpressionType::Variable:
-					visitedNodeContents.push_back(current.getVariable().name);
-					break;
-				case ExpressionType::Literal:
-					// We expect to only find integer literals in our tests
-					visitedNodeContents.push_back(static_cast< std::string >(current.getLiteral()));
-					break;
-				case ExpressionType::Operator:
-					switch (current.getOperator()) {
-						case ExpressionOperator::Plus:
-							visitedNodeContents.emplace_back("+");
-							break;
-						case ExpressionOperator::Times:
-							visitedNodeContents.emplace_back("*");
-							break;
-					}
-					break;
-			}
-		}
-
-		return visitedNodeContents;
+	for (auto iter = begin; iter != end; ++iter) {
+		visitedExpressions.push_back(*iter);
 	}
-};
 
-TEST_P(IterationTest, iteration) {
-	ExpressionTree< Variable > tree = treeFromPostfix(std::get< 0 >(GetParam()));
+	std::vector< std::string > visitedNodeContents;
+	for (ConstExpression< Variable > &current : visitedExpressions) {
+		switch (current.getType()) {
+			case ExpressionType::Variable:
+				visitedNodeContents.push_back(current.getVariable().name);
+				break;
+			case ExpressionType::Literal:
+				// We expect to only find integer literals in our tests
+				visitedNodeContents.push_back(static_cast< std::string >(current.getLiteral()));
+				break;
+			case ExpressionType::Operator:
+				switch (current.getOperator()) {
+					case ExpressionOperator::Plus:
+						visitedNodeContents.emplace_back("+");
+						break;
+					case ExpressionOperator::Times:
+						visitedNodeContents.emplace_back("*");
+						break;
+				}
+				break;
+		}
+	}
 
-	std::vector< std::string > visitedNodes = visitNodes(std::get< 1 >(GetParam()), tree);
-	std::vector< std::string > constVisitedNodes =
-		visitNodes(std::get< 1 >(GetParam()),
-				   static_cast< std::add_lvalue_reference_t< std::add_const_t< decltype(tree) > > >(tree));
-
-	EXPECT_EQ(visitedNodes, std::get< 2 >(GetParam()));
-	EXPECT_EQ(constVisitedNodes, std::get< 2 >(GetParam()));
+	return visitedNodeContents;
 }
 
-INSTANTIATE_TEST_SUITE_P(
-	ExpressionTree, IterationTest,
-	::testing::Values(
-		/*
-		 *    *
-		 *   / \
-		 *  2   x
-		 */
-		IterationTest::ParamPack{ "2 x *", TreeTraversal::DepthFirst_PostOrder, { "2", "x", "*" } },
-		IterationTest::ParamPack{ "2 x *", TreeTraversal::DepthFirst_PreOrder, { "*", "2", "x" } },
-		IterationTest::ParamPack{ "2 x *", TreeTraversal::DepthFirst_InOrder, { "2", "*", "x" } },
-		/*
-		 *      +
-		 *     / \
-		 *    *   3
-		 *   / \
-		 *  2   x
-		 */
-		IterationTest::ParamPack{ "2 x * 3 +", TreeTraversal::DepthFirst_PostOrder, { "2", "x", "*", "3", "+" } },
-		IterationTest::ParamPack{ "2 x * 3 +", TreeTraversal::DepthFirst_PreOrder, { "+", "*", "2", "x", "3" } },
-		IterationTest::ParamPack{ "2 x * 3 +", TreeTraversal::DepthFirst_InOrder, { "2", "*", "x", "+", "3" } }));
+template< typename TreeType >
+auto visitNodes(TreeTraversal traversalOrder, TreeType &tree) -> std::vector< std::string > {
+	switch (traversalOrder) {
+		case TreeTraversal::DepthFirst_InOrder:
+			return visitNodes(tree.template begin< TreeTraversal::DepthFirst_InOrder >(),
+							  tree.template end< TreeTraversal::DepthFirst_InOrder >());
+		case TreeTraversal::DepthFirst_PreOrder:
+			return visitNodes(tree.template begin< TreeTraversal::DepthFirst_PreOrder >(),
+							  tree.template end< TreeTraversal::DepthFirst_PreOrder >());
+		case TreeTraversal::DepthFirst_PostOrder:
+			return visitNodes(tree.template begin< TreeTraversal::DepthFirst_PostOrder >(),
+							  tree.template end< TreeTraversal::DepthFirst_PostOrder >());
+	}
+
+	HEDLEY_UNREACHABLE();
+}
+
+
+class IterationTest : public ::testing::TestWithParam< std::tuple< TreeTraversal, std::size_t > > {
+public:
+	using ParamPack = std::tuple< TreeTraversal, std::size_t >;
+
+protected:
+	/*
+	 *    *
+	 *   / \
+	 *  2   x
+	 */
+	ExpressionTree< Variable > m_smallTree = treeFromPostfix("2 x *");
+	std::map< TreeTraversal, std::vector< std::string > > m_smallTreeNodeIterationOrder{
+		{ TreeTraversal::DepthFirst_PostOrder, { "2", "x", "*" } },
+		{ TreeTraversal::DepthFirst_PreOrder, { "*", "2", "x" } },
+		{ TreeTraversal::DepthFirst_InOrder, { "2", "*", "x" } },
+	};
+
+	/*
+	 *      +
+	 *     / \
+	 *    *   3
+	 *   / \
+	 *  2   x
+	 */
+	ExpressionTree< Variable > m_mediumTree = treeFromPostfix("2 x * 3 +");
+	std::map< TreeTraversal, std::vector< std::string > > m_mediumTreeNodeIterationOrder{
+		{ TreeTraversal::DepthFirst_PostOrder, { "2", "x", "*", "3", "+" } },
+		{ TreeTraversal::DepthFirst_PreOrder, { "+", "*", "2", "x", "3" } },
+		{ TreeTraversal::DepthFirst_InOrder, { "2", "*", "x", "+", "3" } },
+	};
+
+	std::array< ExpressionTree< Variable > *, 2 > m_trees                        = { &m_smallTree, &m_mediumTree };
+	std::array< decltype(m_smallTreeNodeIterationOrder) *, 2 > m_iterationOrders = { &m_smallTreeNodeIterationOrder,
+																					 &m_mediumTreeNodeIterationOrder };
+};
+
+template< TreeTraversal traversalOrder, bool isConst > void test_iteration_anchors() {
+	/*
+	 *      +
+	 *     / \
+	 *    *   3
+	 *   / \
+	 *  2   x
+	 */
+	std::conditional_t< isConst, const ExpressionTree< Variable >, ExpressionTree< Variable > > tree =
+		treeFromPostfix("2 x * 3 +");
+
+	using Expression = std::conditional_t< isConst, ConstExpression< Variable >, Expression< Variable > >;
+
+	Expression plusExpr  = tree.getRoot();
+	Expression timesExpr = tree.getRoot().getLeftArg();
+	Expression threeExpr = tree.getRoot().getRightArg();
+	Expression twoExpr   = timesExpr.getLeftArg();
+	Expression varExpr   = timesExpr.getRightArg();
+
+	ASSERT_EQ(plusExpr.getOperator(), ExpressionOperator::Plus);
+	ASSERT_EQ(timesExpr.getOperator(), ExpressionOperator::Times);
+	ASSERT_EQ(threeExpr.getLiteral(), Fraction(3));
+	ASSERT_EQ(twoExpr.getLiteral(), Fraction(2));
+	ASSERT_EQ(varExpr.getVariable(), Variable{ "x" });
+
+	using Core = details::ExpressionTreeIteratorCore< Variable, isConst, traversalOrder >;
+
+	// From root node
+	ASSERT_EQ(Core::at(tree, plusExpr).dereference(), plusExpr);
+	ASSERT_EQ(Core::after(tree, plusExpr), [&]() {
+		switch (traversalOrder) {
+			case TreeTraversal::DepthFirst_InOrder:
+				return Core::at(tree, threeExpr);
+			case TreeTraversal::DepthFirst_PostOrder:
+				return Core::end(tree);
+			case TreeTraversal::DepthFirst_PreOrder:
+				return Core::at(tree, timesExpr);
+		}
+	}());
+	ASSERT_EQ(Core::fromRoot(tree, plusExpr).dereference(), [&]() {
+		switch (traversalOrder) {
+			case TreeTraversal::DepthFirst_InOrder:
+			case TreeTraversal::DepthFirst_PostOrder:
+				return twoExpr;
+			case TreeTraversal::DepthFirst_PreOrder:
+				return plusExpr;
+		}
+	}());
+	ASSERT_EQ(Core::afterRoot(tree, plusExpr), Core::end(tree));
+
+	// From binary, non-root Node
+	ASSERT_EQ(Core::at(tree, timesExpr).dereference(), timesExpr);
+	ASSERT_EQ(Core::after(tree, timesExpr).dereference(), [&]() {
+		switch (traversalOrder) {
+			case TreeTraversal::DepthFirst_InOrder:
+				return varExpr;
+			case TreeTraversal::DepthFirst_PostOrder:
+				return threeExpr;
+			case TreeTraversal::DepthFirst_PreOrder:
+				return twoExpr;
+		}
+	}());
+	ASSERT_EQ(Core::fromRoot(tree, timesExpr).dereference(), [&]() {
+		switch (traversalOrder) {
+			case TreeTraversal::DepthFirst_InOrder:
+			case TreeTraversal::DepthFirst_PostOrder:
+				return twoExpr;
+			case TreeTraversal::DepthFirst_PreOrder:
+				return timesExpr;
+		}
+	}());
+	ASSERT_EQ(Core::afterRoot(tree, timesExpr).dereference(), [&]() {
+		switch (traversalOrder) {
+			case TreeTraversal::DepthFirst_InOrder:
+				return plusExpr;
+			case TreeTraversal::DepthFirst_PostOrder:
+			case TreeTraversal::DepthFirst_PreOrder:
+				return threeExpr;
+		}
+	}());
+
+	// From non-root, leaf Node
+	ASSERT_EQ(Core::at(tree, twoExpr).dereference(), twoExpr);
+	ASSERT_EQ(Core::after(tree, twoExpr).dereference(), [&]() {
+		switch (traversalOrder) {
+			case TreeTraversal::DepthFirst_InOrder:
+				return timesExpr;
+			case TreeTraversal::DepthFirst_PostOrder:
+			case TreeTraversal::DepthFirst_PreOrder:
+				return varExpr;
+		}
+	}());
+	ASSERT_EQ(Core::fromRoot(tree, twoExpr).dereference(), twoExpr);
+	ASSERT_EQ(Core::afterRoot(tree, twoExpr).dereference(), [&]() {
+		switch (traversalOrder) {
+			case TreeTraversal::DepthFirst_InOrder:
+				return timesExpr;
+			case TreeTraversal::DepthFirst_PostOrder:
+			case TreeTraversal::DepthFirst_PreOrder:
+				return varExpr;
+		}
+	}());
+
+	// From root, leaf Node
+	decltype(tree) leafTree = treeFromPostfix("x");
+	ASSERT_EQ(Core::at(leafTree, leafTree.getRoot()).dereference(), leafTree.getRoot());
+	ASSERT_EQ(Core::after(leafTree, leafTree.getRoot()), Core::end(leafTree));
+	ASSERT_EQ(Core::fromRoot(leafTree, leafTree.getRoot()).dereference(), leafTree.getRoot());
+	ASSERT_EQ(Core::afterRoot(leafTree, leafTree.getRoot()), Core::end(leafTree));
+}
+
+TEST_P(IterationTest, iteration_anchors) {
+	const TreeTraversal traversalOrder = std::get< 0 >(GetParam());
+	const bool accessTreeAsConst       = static_cast< bool >(std::get< 1 >(GetParam()));
+
+	switch (traversalOrder) {
+		case TreeTraversal::DepthFirst_InOrder:
+			if (accessTreeAsConst) {
+				test_iteration_anchors< TreeTraversal::DepthFirst_InOrder, true >();
+			} else {
+				test_iteration_anchors< TreeTraversal::DepthFirst_InOrder, false >();
+			}
+			break;
+		case TreeTraversal::DepthFirst_PreOrder:
+			if (accessTreeAsConst) {
+				test_iteration_anchors< TreeTraversal::DepthFirst_PreOrder, true >();
+			} else {
+				test_iteration_anchors< TreeTraversal::DepthFirst_PreOrder, false >();
+			}
+			break;
+		case TreeTraversal::DepthFirst_PostOrder:
+			if (accessTreeAsConst) {
+				test_iteration_anchors< TreeTraversal::DepthFirst_PostOrder, true >();
+			} else {
+				test_iteration_anchors< TreeTraversal::DepthFirst_PostOrder, false >();
+			}
+			break;
+	}
+}
+
+TEST_P(IterationTest, full_iteration) {
+	const TreeTraversal traversalOrder    = std::get< 0 >(GetParam());
+	const ExpressionTree< Variable > tree = *m_trees.at(std::get< 1 >(GetParam()));
+	const std::vector< std::string > expectedIterationOrder =
+		(*m_iterationOrders.at(std::get< 1 >(GetParam())))[traversalOrder];
+
+	const std::vector< std::string > visitedNodes      = visitNodes(traversalOrder, tree);
+	const std::vector< std::string > constVisitedNodes = visitNodes(
+		traversalOrder, static_cast< std::add_lvalue_reference_t< std::add_const_t< decltype(tree) > > >(tree));
+
+	EXPECT_EQ(visitedNodes, expectedIterationOrder);
+	EXPECT_EQ(constVisitedNodes, expectedIterationOrder);
+}
+
+template< TreeTraversal traversalOrder, bool isConst > void test_partial_iteration() {
+	/*
+	 *      +
+	 *     / \
+	 *    *   3
+	 *   / \
+	 *  2   x
+	 */
+	std::conditional_t< isConst, const ExpressionTree< Variable >, ExpressionTree< Variable > > tree =
+		treeFromPostfix("2 x * 3 +");
+
+	using Core     = details::ExpressionTreeIteratorCore< Variable, isConst, traversalOrder >;
+	using Iterator = ExpressionTree< Variable >::iterator_template< isConst, traversalOrder >;
+
+	std::vector< std::string > expectedNodeVisits;
+	std::vector< std::string > visitedNodes;
+
+	{
+		// Start iterating as normal, but stop just before the root node is visited
+		auto begin = tree.template begin< traversalOrder >();
+		auto end   = Iterator(Core::at(tree, tree.getRoot()));
+
+		visitedNodes       = visitNodes(begin, end);
+		expectedNodeVisits = []() -> std::vector< std::string > {
+			switch (traversalOrder) {
+				case TreeTraversal::DepthFirst_InOrder:
+					return { "2", "*", "x" };
+				case TreeTraversal::DepthFirst_PostOrder:
+					return { "2", "x", "*", "3" };
+				case TreeTraversal::DepthFirst_PreOrder:
+					return {};
+			}
+		}();
+		EXPECT_EQ(visitedNodes, expectedNodeVisits);
+	}
+	{
+		// Start iterating as normal, but stop just after the root node has been visited
+		auto begin = tree.template begin< traversalOrder >();
+		auto end   = Iterator(Core::after(tree, tree.getRoot()));
+
+		visitedNodes       = visitNodes(begin, end);
+		expectedNodeVisits = []() -> std::vector< std::string > {
+			switch (traversalOrder) {
+				case TreeTraversal::DepthFirst_InOrder:
+					return { "2", "*", "x", "+" };
+				case TreeTraversal::DepthFirst_PostOrder:
+					return { "2", "x", "*", "3", "+" };
+				case TreeTraversal::DepthFirst_PreOrder:
+					return { "+" };
+			}
+		}();
+		EXPECT_EQ(visitedNodes, expectedNodeVisits);
+	}
+	{
+		// Iterate only over the sub-tree representing the multiplication
+		auto begin = Iterator(Core::fromRoot(tree, tree.getRoot().getLeftArg()));
+		auto end   = Iterator(Core::afterRoot(tree, tree.getRoot().getLeftArg()));
+
+		std::cout << "Root: " << tree.getRoot() << std::endl;
+		std::cout << "Left arg: " << tree.getRoot().getLeftArg() << std::endl;
+		std::cout << "First visited: " << *begin << std::endl;
+
+		visitedNodes       = visitNodes(begin, end);
+		expectedNodeVisits = [&]() -> std::vector< std::string > {
+			switch (traversalOrder) {
+				case TreeTraversal::DepthFirst_InOrder:
+					EXPECT_EQ(begin->getType(), ExpressionType::Literal);
+					return { "2", "*", "x" };
+				case TreeTraversal::DepthFirst_PostOrder:
+					EXPECT_EQ(begin->getType(), ExpressionType::Literal);
+					return { "2", "x", "*" };
+				case TreeTraversal::DepthFirst_PreOrder:
+					EXPECT_EQ(begin->getType(), ExpressionType::Operator);
+					return { "*", "2", "x" };
+			}
+		}();
+
+		EXPECT_EQ(visitedNodes, expectedNodeVisits);
+	}
+}
+
+TEST_P(IterationTest, partial_iteration) {
+	const TreeTraversal traversalOrder = std::get< 0 >(GetParam());
+	const bool accessTreeAsConst       = static_cast< bool >(std::get< 1 >(GetParam()));
+
+	switch (traversalOrder) {
+		case TreeTraversal::DepthFirst_InOrder:
+			if (accessTreeAsConst) {
+				test_partial_iteration< TreeTraversal::DepthFirst_InOrder, true >();
+			} else {
+				test_partial_iteration< TreeTraversal::DepthFirst_InOrder, false >();
+			}
+			break;
+		case TreeTraversal::DepthFirst_PreOrder:
+			if (accessTreeAsConst) {
+				test_partial_iteration< TreeTraversal::DepthFirst_PreOrder, true >();
+			} else {
+				test_partial_iteration< TreeTraversal::DepthFirst_PreOrder, false >();
+			}
+			break;
+		case TreeTraversal::DepthFirst_PostOrder:
+			if (accessTreeAsConst) {
+				test_partial_iteration< TreeTraversal::DepthFirst_PostOrder, true >();
+			} else {
+				test_partial_iteration< TreeTraversal::DepthFirst_PostOrder, false >();
+			}
+			break;
+	}
+}
+
+INSTANTIATE_TEST_SUITE_P(ExpressionTree, IterationTest,
+						 ::testing::Combine(::testing::Values(TreeTraversal::DepthFirst_InOrder,
+															  TreeTraversal::DepthFirst_PostOrder,
+															  TreeTraversal::DepthFirst_PreOrder),
+											::testing::Values(0, 1)));
+
+
+
+TEST(ExpressionTree, iterator_convertability) {
+	ExpressionTree< Variable > tree = treeFromPostfix("a b +");
+
+	// This is a compile-time check that produces a compiler error, if it fails
+	auto mutIter   = tree.begin();
+	auto constIter = tree.cbegin();
+	constIter      = mutIter; // mutable to const iterator must be possible
+
+	(void) constIter;
+}
+
 
 
 class EvaluationTest : public ::testing::TestWithParam< std::tuple< std::string, int > > {};
@@ -265,15 +548,3 @@ INSTANTIATE_TEST_SUITE_P(ExpressionTree, EvaluationTest,
 							 std::tuple< std::string, int >{ "2 a + 4 2 -1 b * + * *", 40 },
 							 // 2 + (4 * (a * (2 + -3) + b) + -1 * b) + (4 * 3 * 2 * 1)
 							 std::tuple< std::string, int >{ "2 4 a 2 -3 + * b + * -1 b * + + 4 3 * 2 * 1 * +", 74 }));
-
-
-TEST(ExpressionTree, iterator_convertability) {
-	ExpressionTree< Variable > tree = treeFromPostfix("a b +");
-
-	// This is a compile-time check that produces a compiler error, if it fails
-	auto mutIter   = tree.begin();
-	auto constIter = tree.cbegin();
-	constIter      = mutIter; // mutable to const iterator must be possible
-
-	(void) constIter;
-}


### PR DESCRIPTION
This allows to perform substitutions in an already created `ExpressionTree`. Substitutions can be many-to-one, one-to-many and many-to-many. In the current state, the code does not try to reuse the memory that has been occupied by the replaced sub-tree. Doing so is an optimization that can (and probably should) be done at some point in the future.